### PR TITLE
fix: switched instructions from blockquote to comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
-# About [project]
+# Project name
 
-> Describe your project's features, functionality and target audience
+<!-- Describe your project's features, functionality and target audience -->
 
 ## Installation
 
-> Provide detailed step-by-step installation instructions
+<!-- Provide detailed step-by-step installation instructions -->
 
 ## Documentation
 
-> Developer-oriented documentation can be published on GitHub, but all product
-  documentation must be published on <https://docs.oracle.com>.
+<!-- Developer-oriented documentation can be published on GitHub, but all product
+     documentation must be published on <https://docs.oracle.com>. -->
 
 ## Examples
 
-> Describe any included examples or provide a link to a demo/tutorial
+<!-- Describe any included examples or provide a link to a demo/tutorial -->
 
 ## Help
 
-> Inform users on where to get help or how to receive official support from Oracle
-  (if applicable).
+<!-- Inform users on where to get help or how to receive official support from Oracle
+     (if applicable). -->
 
 ## Contributing
 
-> If your project has specific contribution requirements, update the
-  `CONTRIBUTING.md` file to ensure those requirements are clearly explained.
+<!-- If your project has specific contribution requirements, update the
+    CONTRIBUTING.md file to ensure those requirements are clearly explained. -->
 
 This project welcomes contributions from the community. Before submitting a pull
 request, please [review our contribution guide](./CONTRIBUTING.md).
@@ -35,12 +35,14 @@ vulnerability disclosure process.
 
 ## License
 
-> The correct copyright notice format for both documentation and software
-  is `Copyright (c) [year,] year Oracle and/or its affiliates.`
-  You must include the year the content was first released (on any platform) and
-  the most recent year in which it was revised.
+<!-- The correct copyright notice format for both documentation and software
+    is "Copyright (c) [year,] year Oracle and/or its affiliates."
+    You must include the year the content was first released (on any platform) and
+    the most recent year in which it was revised. -->
 
 Copyright (c) 2021 Oracle and/or its affiliates.
+
+<!-- Replace this statement if your project is not licensed under the UPL -->
 
 Released under the Universal Permissive License v1.0 as shown at
 <https://oss.oracle.com/licenses/upl/>.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,10 @@ and privacy of all our users.
 
 Please do NOT raise a GitHub Issue to report a security vulnerability. If you
 believe you have found a security vulnerability, please submit a report to
-<mailto:secalert_us@oracle.com> preferably with a proof of concept. Please review
-some additional information on [how to report security vulnerabilities to Oracle][1].
+[secalert_us@oracle.com][1] preferably with a proof of concept. Please review
+some additional information on [how to report security vulnerabilities to Oracle][2].
 We encourage people who contact Oracle Security to use email encryption using
-[our encryption key][2].
+[our encryption key][3].
 
 We ask that you do not use other channels or contact the project maintainers
 directly.
@@ -24,7 +24,7 @@ will typically release security fixes in conjunction with the
 [Oracle Critical Patch Update][3] program. Security updates are released on the
 Tuesday closest to the 17th day of January, April, July and October. A pre-release
 announcement will be published on the Thursday preceding each release. Additional
-information, including past advisories, is available on our [security alerts][3]
+information, including past advisories, is available on our [security alerts][4]
 page.
 
 ## Security-related information
@@ -34,6 +34,7 @@ for secure use, or any known security issues in our documentation. Please note
 that labs and sample code are intended to demonstrate a concept and may not be
 sufficiently hardened for production use.
 
-[1]: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
-[2]: https://www.oracle.com/security-alerts/encryptionkey.html
-[3]: https://www.oracle.com/security-alerts/
+[1]: mailto:secalert_us@oracle.com
+[2]: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
+[3]: https://www.oracle.com/security-alerts/encryptionkey.html
+[4]: https://www.oracle.com/security-alerts/


### PR DESCRIPTION
This will reduce the chance of instructions being published as
user-visible text.

Signed-off-by: Avi Miller <avi.miller@oracle.com>