### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,9 +21,8 @@ security features are welcome on GitHub Issues.
 
 Security updates will be released on a regular cadence. Many of our projects
 will typically release security fixes in conjunction with the
-[Oracle Critical Patch Update][3] program. Additional
-information, including past advisories, is available on our [security alerts][4]
-page.
+[Oracle Critical Patch Update][3] program. Check out the program page for information about 
+security alerts, CPU release schedule, and more.
 
 ## Security-related information
 
@@ -34,5 +33,4 @@ sufficiently hardened for production use.
 
 [1]: mailto:secalert_us@oracle.com
 [2]: https://www.oracle.com/corporate/security-practices/assurance/vulnerability/reporting.html
-[3]: https://www.oracle.com/security-alerts/encryptionkey.html
-[4]: https://www.oracle.com/security-alerts/
+[3]: https://www.oracle.com/security-alerts/


### PR DESCRIPTION
removing a link to https://www.oracle.com/security-alerts/encryptionkey.html which I don't think should be there